### PR TITLE
Update to work with Julia v0.5.0

### DIFF
--- a/examples/examples.jl
+++ b/examples/examples.jl
@@ -2,8 +2,8 @@ using CellularAutomata
 
 #Rule 90 1-dim Cellular Automata run for 15 generations
 function rule90example()
-    #init=int(zeros(1000))
-    #init[int(1000/2)]=1
+    #init=Array{Int}(zeros(1000))
+    #init[Int(1000/2)]=1
     tic()
     ca = CellularAutomaton(90, 15)
     toc()
@@ -11,9 +11,9 @@ function rule90example()
     ca
 end
 
-#Turbine pattern from Conway's game of life 
+#Turbine pattern from Conway's game of life
 function turbine_example()
-    init = int(zeros(20,20))
+    init = Array{Int}(zeros(20,20))
     init[4, 4:9] = 1
     init[5, 4:9] = 1
 
@@ -29,4 +29,3 @@ function turbine_example()
     #game of life
     CA2d([3], [2,3], init, 5)
 end
-

--- a/src/1dim.jl
+++ b/src/1dim.jl
@@ -17,14 +17,14 @@ type CellularAutomaton
 
         w = length(init)
         cells = Array(Int8, gen, w)
-        cells[1,:] = int8(init[:])'
+        cells[1,:] = Array{Int8}(init[:])'
 
         if k == 2
             #Elementary CA
             mp = reverse(Int8[k^i for i = 0:k])
         else
             #Totalistic CA
-            mp = int8(ones(k+1))
+            mp = Array{Int8}(ones(k+1))
         end
 
         for i = 2:gen
@@ -40,7 +40,7 @@ type CellularAutomaton
                         q = q-w
                     end
 
-                    ind += mp[s]*cells[i-1, q] 
+                    ind += mp[s]*cells[i-1, q]
                     s += 1
                 end
                 cells[i,j] = ruleset[ind+1]
@@ -52,9 +52,9 @@ type CellularAutomaton
 
     #Quick setup for one seed cell in the center
     function CellularAutomaton(N::Int, gen::Int; kvs...)
-        init = int(zeros(2*gen))
+        init = Array{Int}(zeros(2*gen))
         init[gen] = 1
-        
+
         CellularAutomaton(N, init, gen; kvs...)
     end
 end
@@ -71,4 +71,3 @@ function rule(n::Int, k=2, r=1)
         return digits(n, k, (2r+1)k-2)
     end
 end
-

--- a/src/2dim.jl
+++ b/src/2dim.jl
@@ -11,21 +11,21 @@ type CA2d
     #Internal values
     cells::Array{Int8, 3}
 
-    function CA2d(B::Array{Int,1}, 
-                  S::Array{Int,1}, 
-                  init::Array{Int,2}, 
-                  gen::Int, 
-                  k::Int=2, 
+    function CA2d(B::Array{Int,1},
+                  S::Array{Int,1},
+                  init::Array{Int,2},
+                  gen::Int,
+                  k::Int=2,
                   r::Int=1)
 
         h, w = size(init)
         cells = Array(Int8, h, w, gen)
-        cells[:, :, 1] = int8(init[:, :])
+        cells[:, :, 1] = Array{Int8}(init[:, :])
 
         for g = 2:gen
             for i = 1:h, j = 1:w
                 cc = -cells[i, j, g-1]
-                for p = (i-r):(i+r), q = (j-r):(j+r) 
+                for p = (i-r):(i+r), q = (j-r):(j+r)
 
                     #Cyclic boundary conditions
                     if p < 1; p = h-p; end
@@ -52,5 +52,3 @@ function eval_rule(cc, olds, B, S, k=2)
 
     return 0
 end
-
-

--- a/src/CellularAutomata.jl
+++ b/src/CellularAutomata.jl
@@ -11,7 +11,7 @@ export CellularAutomaton,
        show
 
 #Print CA to screen
-function show(io::IO, ca::CellularAutomaton) 
+function show(io::IO, ca::CellularAutomaton)
     io2 = IOBuffer()
 
     arr = ca.cells
@@ -38,11 +38,11 @@ function show(io::IO, ca::CellularAutomaton)
         print(io2,"\n")
     end
 
-    print(io, bytestring(io2))
+    print(io, String(io2))
 end
 
 #Print CA to screen
-function show(io::IO, ca::CA2d) 
+function show(io::IO, ca::CA2d)
     io2 = IOBuffer()
 
     arr = ca.cells
@@ -68,7 +68,7 @@ function show(io::IO, ca::CA2d)
         print(io2,"\n\n")
     end
 
-    print(io, bytestring(io2))
+    print(io, String(io2))
 end
 
 

--- a/src/display.jl
+++ b/src/display.jl
@@ -32,7 +32,7 @@ function sim_life(init::Array{Int,2},B, S)
             last = t; f = 0
         end
         M = CA2d(B, S, init, 2).cells
-        init = int(M[:, :, 2]) 
+        init = Array{Int}(M[:, :, 2])
         f += 1
         sleep(0.01)
     end
@@ -40,7 +40,7 @@ end
 
 
 #turbine pattern
-#init = int(zeros(20,20))
+#init = Array{Int}(zeros(20,20))
 #init[4, 4:9] = 1
 #init[5, 4:9] = 1
 
@@ -53,12 +53,12 @@ end
 #init[7:12, 4] = 1
 #init[7:12, 5] = 1
 
-init = int(zeros(600,600))
-init[250:350, 250:350] = int(rand(101,101))
-#init[295:305, 295:305] = int(rand(11,11))
+init = Array{Int}(zeros(600,600))
+init[250:350, 250:350] = Array{Int}(rand(101,101))
+#init[295:305, 295:305] = Array{Int}(rand(11,11))
 
 
-#init = int(rand(1000, 1000))
+#init = Array{Int}(rand(1000, 1000))
 
 #game of life
 sim_life(init,[3], [2,3])
@@ -80,4 +80,3 @@ sim_life(init,[3], [2,3])
 
 #34 life
 #sim_life(init,[3,4],[3,4])
-

--- a/test/conway_test.jl
+++ b/test/conway_test.jl
@@ -7,7 +7,7 @@ export blinker_test, turbine_test
 
 # Function to test Conway's blinker oscillator and toad oscillator
 function blinker_test()
-  init = int(zeros(10,10))
+  init = Array{Int}(zeros(10,10))
 
   # 'Toad Oscillator'
   init[6, 4] = 1
@@ -40,7 +40,7 @@ end
 
 # Function to test Conway's turbine automota which repeats every ninth step
 function turbine_test()
-  init = int(zeros(20,20))
+  init = Array{Int}(zeros(20,20))
   init[4, 4:9] = 1
   init[5, 4:9] = 1
 
@@ -60,4 +60,3 @@ function turbine_test()
   end
 end
 end
-


### PR DESCRIPTION
Tests passing with Julia v0.5.0. Most errors had to do with calling deprecated function `int`.