### PR TITLE
error fix for r>1 1d elementary ca

### DIFF
--- a/src/1dim.jl
+++ b/src/1dim.jl
@@ -21,7 +21,7 @@ type CellularAutomaton
 
         if k == 2
             #Elementary CA
-            mp = reverse(Int8[k^i for i = 0:k])
+            mp = reverse(Int8[k^i for i = 0:2r])
         else
             #Totalistic CA
             mp = Array{Int8}(ones(k+1))


### PR DESCRIPTION
mp was sized incorrectly, but it coincidentally worked out for r=1. shouldn't give a bounds error for r>1 now